### PR TITLE
Fixed fatal error on product save

### DIFF
--- a/src/Marello/Bundle/OroCommerceBundle/EventListener/Doctrine/ReverseSyncProductListener.php
+++ b/src/Marello/Bundle/OroCommerceBundle/EventListener/Doctrine/ReverseSyncProductListener.php
@@ -159,7 +159,8 @@ class ReverseSyncProductListener
                     /** @var SalesChannel $salesChannel */
                     $salesChannel = $entity->getSalesChannel();
                     if ($salesChannel &&
-                        $salesChannel->getIntegrationChannel()->getType() === OroCommerceChannelType::TYPE ) {
+                        $salesChannel->getIntegrationChannel() &&
+                        $salesChannel->getIntegrationChannel()->getType() === OroCommerceChannelType::TYPE) {
                         $result[$product->getSku()] = $product;
                     }
                 } elseif ($class === Product::class) {


### PR DESCRIPTION
Got "Call to a member function getType() on null" error when saving product if the channel is declared without integration