### PR TITLE
Fix bug affecting all integrations but this one

### DIFF
--- a/src/Marello/Bundle/OroCommerceBundle/Form/Extension/ChannelConnectorsExtension.php
+++ b/src/Marello/Bundle/OroCommerceBundle/Form/Extension/ChannelConnectorsExtension.php
@@ -30,6 +30,9 @@ class ChannelConnectorsExtension extends AbstractTypeExtension
     public function onPreSubmit(FormEvent $event)
     {
         $data = $event->getData();
+        if (!$data || $data->getType() !== OroCommerceChannelType::TYPE) {
+            return;
+        }
         $data['synchronizationSettings'] = [
             'isTwoWaySyncEnabled' => 1,
             'syncPriority' => 'local'


### PR DESCRIPTION
If an integration does not implement the `synchronizationSettings` field (almost all but the OroCRM to Magento connector and this integration), an error message is thrown when creating a new integration or while updating it.